### PR TITLE
Pluging in SynchronizationContext.

### DIFF
--- a/Src/WorkplaceEngine/Contract/IWorkItemProcessor.cs
+++ b/Src/WorkplaceEngine/Contract/IWorkItemProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WorkplaceEngine.Contract
 {
@@ -14,6 +15,6 @@ namespace WorkplaceEngine.Contract
         /// </summary>
         /// <param name="items">Items to process</param>
         /// <param name="cancel">Cooperative cancellation token</param>
-        void Process(TWorkItem[] items, CancellationToken cancel);
+        void Process(TWorkItem[] items, CancellationToken cancel, TaskScheduler scheduler);
     }
 }

--- a/Src/WorkplaceEngine/Execution/Executor.cs
+++ b/Src/WorkplaceEngine/Execution/Executor.cs
@@ -67,9 +67,10 @@ namespace WorkplaceEngine.Execution
                 State = WorkState.InProgress;
             }
 
+			var scheduler = TaskScheduler.FromCurrentSynchronizationContext();
             await Task.Run(() =>
             {
-                itemsProcessor.Process(items, cancellation.Token);
+                itemsProcessor.Process(items, cancellation.Token, scheduler);
             }).ConfigureAwait(false);
 
             State = WorkState.Finished;

--- a/Src/WorkplaceEngine/Processors/PLinq.cs
+++ b/Src/WorkplaceEngine/Processors/PLinq.cs
@@ -1,6 +1,7 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using WorkplaceEngine.Contract;
 
 namespace WorkplaceEngine.Processors
@@ -11,7 +12,7 @@ namespace WorkplaceEngine.Processors
     [Description("PLinq")]
     public class PLinq : IWorkItemProcessor<ISyncWorkItem>
     {
-        public void Process(ISyncWorkItem[] items, CancellationToken cancel)
+        public void Process(ISyncWorkItem[] items, CancellationToken cancel, TaskScheduler scheduler)
         {
             items.AsParallel().ForAll(i => i.WorkHard(cancel));
         }

--- a/Src/WorkplaceEngine/Processors/ParallelFor.cs
+++ b/Src/WorkplaceEngine/Processors/ParallelFor.cs
@@ -11,9 +11,9 @@ namespace WorkplaceEngine.Processors
     [Description("Parallel For")]
     public class ParallelFor : IWorkItemProcessor<ISyncWorkItem>
     {
-        public void Process(ISyncWorkItem[] items, CancellationToken cancel)
+        public void Process(ISyncWorkItem[] items, CancellationToken cancel, TaskScheduler scheduler)
         {
-            Parallel.For(0, items.Length, i =>
+            Parallel.For(0, items.Length, new ParallelOptions() { TaskScheduler = scheduler }, i =>
             {
                 items[i].WorkHard(cancel);
             });

--- a/Src/WorkplaceEngine/Processors/SynchronousLoop.cs
+++ b/Src/WorkplaceEngine/Processors/SynchronousLoop.cs
@@ -1,5 +1,6 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Threading;
+using System.Threading.Tasks;
 using WorkplaceEngine.Contract;
 
 namespace WorkplaceEngine.Processors
@@ -10,7 +11,7 @@ namespace WorkplaceEngine.Processors
     [Description("Synchronous Loop")]
     public class SynchronousLoop : IWorkItemProcessor<ISyncWorkItem>
     {
-        public void Process(ISyncWorkItem[] items, CancellationToken cancel)
+        public void Process(ISyncWorkItem[] items, CancellationToken cancel, TaskScheduler scheduler)
         {
             for (int i = 0; i < items.Length; i++)
             {

--- a/Src/WorkplaceEngine/Processors/Threads.cs
+++ b/Src/WorkplaceEngine/Processors/Threads.cs
@@ -15,7 +15,7 @@ namespace WorkplaceEngine.Processors
     [Description("Single thread per work item")]
     public class Threads : IWorkItemProcessor<ISyncWorkItem>
     {
-        public void Process(ISyncWorkItem[] items, CancellationToken cancel)
+        public void Process(ISyncWorkItem[] items, CancellationToken cancel, TaskScheduler scheduler)
         {
             var threads = new Thread[items.Length];
 

--- a/Src/WorkplaceEngine/Processors/ThredPoolEnque.cs
+++ b/Src/WorkplaceEngine/Processors/ThredPoolEnque.cs
@@ -1,5 +1,6 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Threading;
+using System.Threading.Tasks;
 using WorkplaceEngine.Contract;
 
 namespace WorkplaceEngine.Processors
@@ -10,7 +11,7 @@ namespace WorkplaceEngine.Processors
     [Description("ThredPool QueueUserWorkItem")]
     public class ThredPoolEnque : IWorkItemProcessor<ISyncWorkItem>
     {
-        public void Process(ISyncWorkItem[] items, CancellationToken cancel)
+        public void Process(ISyncWorkItem[] items, CancellationToken cancel, TaskScheduler scheduler)
         {
             int finishedCount = 0;
 

--- a/Src/WorkplaceEngine/Processors/WaitAllTaskRun.cs
+++ b/Src/WorkplaceEngine/Processors/WaitAllTaskRun.cs
@@ -12,9 +12,9 @@ namespace WorkplaceEngine.Processors
     [Description("Manual Tasks")]
     public class WaitAllTaskRun : IWorkItemProcessor<ISyncWorkItem>
     {
-        public void Process(ISyncWorkItem[] items, CancellationToken cancel)
+        public void Process(ISyncWorkItem[] items, CancellationToken cancel, TaskScheduler scheduler)
         {
-            Task.WaitAll(items.Select(i => Task.Run(() => i.WorkHard(cancel))).ToArray());
+            Task.WaitAll(items.Select(i => Task.Factory.StartNew(() => i.WorkHard(cancel), default, TaskCreationOptions.None, scheduler)).ToArray());
         }
     }
 }

--- a/Src/WorkplaceEngine/Processors/WaitAllTasks.cs
+++ b/Src/WorkplaceEngine/Processors/WaitAllTasks.cs
@@ -12,7 +12,7 @@ namespace WorkplaceEngine.Processors
     [Description("Manual Tasks")]
     public class WaitAllTasks : IWorkItemProcessor<IAsyncWorkItem>
     {
-        public void Process(IAsyncWorkItem[] items, CancellationToken cancel)
+        public void Process(IAsyncWorkItem[] items, CancellationToken cancel, TaskScheduler scheduler)
         {
             Task.WaitAll(items.Select(i => i.WorkHard(cancel)).ToArray());
         }


### PR DESCRIPTION
Uses `TaskScheduler` where the `SynchronizationContext` is used. Only some items done, because it doesn't make much sense outside tasks.

Also now it nicely shows blocking vs. non-blocking/asynchronous operation.

No need to merge. Just letting you know.